### PR TITLE
Midnight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           show-progress: false
 
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           show-progress: false
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,7 +11,12 @@ read_globals = {
 
 	-- API
     C_UnitAuras = {
-		fields = { 'GetAuraByAuraInstanceID', 'GetAuraDataBySlot', 'GetAuraSlots' }
+		fields = {
+			'GetAuraByAuraInstanceID',
+			'GetAuraDataBySlot',
+			'GetAuraSlots',
+			'IsAuraFilteredOutByInstanceID',
+		},
 	},
 	'CreateFrame',
 	'IsPlayerSpell',

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -12,8 +12,11 @@ read_globals = {
 	-- API
     C_UnitAuras = {
 		fields = {
+			'GetAuraApplicationDisplayCount',
 			'GetAuraByAuraInstanceID',
 			'GetAuraDataBySlot',
+			'GetAuraDispelTypeColor',
+			'GetAuraDuration',
 			'GetAuraSlots',
 			'IsAuraFilteredOutByInstanceID',
 		},

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ It does nothing by itself and requires layout support to do its magic.
 oUF_Dispellable provides functionality to highlight debuffs dispellable by the player. It can display either a texture 
 colored by the debuff type, or an icon representing the found dispellable debuff, or both.
 
-It enables and disables itself automatically based on whether the player can dispel or not and keeps an always updated 
-list of the dispel spells available to the player. It also keeps track of self-dispels like [Grimoire: Imp](http://www.wowdb.com/spells/111859) 
-and [Cleansed by Flame](http://www.wowdb.com/spells/205625) to only highlight the player frame when only those are known.
+Since Midnight the addon relies on the `HARMFUL|RAID` aura filter to get debuffs dispellable by the player. The addon
+does not know in advance if and what debuff types you can dispel and is thus always active, even when the player does
+not know any dispelling spells.
 
 ## How to use (for layout authors)
 
 The element is fully documented and follows the current oUF guidelines for documentation. Please take a look at the code 
-for details and examples. You could also consult the [wiki](https://github.com/Rainrider/oUF_Dispellable/wiki).
+for details and examples.
 
 Please consider making oUF_Dispellable optional for your users. The easiest way is to distribute it with your layout as a 
 separate addon and use something like `if not IsAddOnLoaded('oUF_Dispellable') then return end` before calling its 

--- a/oUF_Dispellable.toc
+++ b/oUF_Dispellable.toc
@@ -1,4 +1,4 @@
-## Interface: 110002
+## Interface: 120000
 ## Title: oUF_Dispellable
 ## Notes: oUF element for highlighting debuffs that are dispellable by the player
 ## Author: Rainrider

--- a/oUF_Dispellable.toc
+++ b/oUF_Dispellable.toc
@@ -4,15 +4,9 @@
 ## Author: Rainrider
 ## Version: @project-version@
 ## RequiredDeps: oUF
-## OptionalDeps: LibStub, LibPlayerSpells-1.0
 
 ## X-Curse-Project-ID: 285395
 ## X-Wago-ID: baNDRgKo
 ## X-WoWI-ID: 24540
-
-#@non-debug@
-# libs\LibStub\LibStub.lua
-# libs\LibPlayerSpells-1.0\lib.xml
-#@end-non-debug@
 
 oUF_Dispellable.lua


### PR DESCRIPTION
Update for Midnight.

### Breaking Changes:

- `UpdateColor` is now defined on the element instead of on the `dispelTexture` sub-widget.
- `UpdateColor` is now passed the unit and the dispellable debuff in place of the dispel type and the color components.
- `UpdateColor` is now called when no dispellable debuff is found.
- Some of the callback arguments and some of the widget attributes are now secrets because of the API changes made by Blizzard in Midnight.

### Added:

- `Dispellable.dispelColorCurve` - a [`color curve object`](https://warcraft.wiki.gg/wiki/ScriptObject_ColorCurveObject) based of `oUF.colors.dispel` and `dispelTexture.dispelAlpha` (or 1 if not set)
- `Dispellable.resetColor` - a [`color object`](https://warcraft.wiki.gg/wiki/ColorMixin) used to reset the colors of the `dispelTexture` and the `dispelIcon.overlay` sub-widgets when no dispellable debuff is found. Defaults to r = 1, g = 1, b = 1, and alpha equal to `dispelTexture.noDispelAlpha` (or 1 if no dispelTexture is set)

### Fixed:

- The element is now always updated, so that the layout does not have to hide the widgets explicitly
- The element is now updated when the currently found dispellable debuff is updated